### PR TITLE
Fix Time.now issue in spec

### DIFF
--- a/spec/timed_buffer_sink_spec.cr
+++ b/spec/timed_buffer_sink_spec.cr
@@ -26,9 +26,9 @@ describe Cute::TimedBufferSink do
       subject.notify 9
       subject.notify 0
 
-      start = Time.now
+      start = Time.local
       Fiber.yield # We're not hitting the time constraint, right?
-      (start - Time.now).should be < 10.milliseconds
+      (start - Time.local).should be < 10.milliseconds
 
       emits.should eq [ [ 1, 2, 3 ], [ 4, 5 ], [ 6, 7 ], [ 8, 9, 0 ] ]
 


### PR DESCRIPTION
Specs were broken because of the removal of Time.now. I swapped it out for Time.local.